### PR TITLE
Add RGBD, RGB and RGB triggered options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Which should start a simulated camera in Gazebo with a few objects in front of i
 
 # Example Usage in URDF
 
-In your robots urdf.xacro include the desired Realsense model along with its gazebo description.
+In your robots urdf.xacro include the desired Realsense model along with its Gazebo description.
 ```xml
 <xacro:include filename="$(find realsense2_description)/urdf/_d415.urdf.xacro" />
 <xacro:include filename="$(find realsense2_gz_description)/urdf/_d415.gazebo.xacro" />
@@ -49,6 +49,18 @@ This plugin can be started from your URDF or world.sdf file.
 ```
 
 you can also refer to the the [example.urdf.xacro](./urdf/example_d415_gazebo.urdf.xacro) included.
+
+## Gazebo only features
+
+Gazebo offers a triggered based RGB camera that can be enabled by passing `triggered="true"` to the Gazebo description xacro.
+Currently this feature does not appear to not work with the RGBD sensor, but will hopefully be added soon.
+Switching the camera to only `trigger` when requested allows developers to better control the computation load required by each sensor.
+Note triggering is not a feature the Realsense hardware offers unfortunately.
+
+To trigger the camera from the command line you can publish on the Gazebo topic `camera_name/trigger`.
+```bash
+ign topic -t "/name/trigger" -m Boolean -p "data: true" -n 1
+```
 
 ## Contributing
 

--- a/urdf/_d415.gazebo.xacro
+++ b/urdf/_d415.gazebo.xacro
@@ -1,98 +1,62 @@
 <?xml version="1.0"?>
 <robot name="gazebo_d415" xmlns:xacro="http://www.ros.org/wiki/xacro" xmlns:ignition="http://gazebosim.org/schema">
 
-<!--
-Gazebo plugins can only be included once so this xacro assumes that a parent will include and configure them.
-This xacro requires Gazebo plugin:
-  - ignition::gazebo::systems::Sensors
-  to publish simulated RGBD camera data
+<xacro:include filename="$(find realsense2_gz_description)/urdf/rgb_camera.gazebo.xacro" />
+<xacro:include filename="$(find realsense2_gz_description)/urdf/rgbd_camera.gazebo.xacro" />
 
-For example:
-<gazebo>
-  <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
-    <render_engine>ogre2</render_engine>
-  </plugin>
-</gazebo>
+<!-- Xacro args
+    name: should match the name value passed to realsense2_description sensor xacro
+    type:  valid values [rgb or rgbd]. Sensor type you would like to simulate
+    fps: the target frame rate of the camera images
+    gz_topic_name: the topic name the image and camera_info are published to Gazebo topics
+    image_width: See Realsense documentation for what the physical sensor supports
+    image_height: See Realsense documentation for what the physical sensor supports
+    trigger: valid values [true, false]. Only supported with 'type=rgb' and will only publish a single image when triggered on Gazebo topic '${name}/trigger'
+             example command line trigger
+             ign topic -t "/name/trigger" -m Boolean -p "data: true" -n 1
 -->
 <xacro:macro name="gazebo_d415" params="
   name:=camera
+  type:=rgbd
   fps:=15
   gz_topic_name:=camera
   image_width:=1280
-  image_height:=720">
+  image_height:=720
+  triggered:=false">
 
     <!-- Realsense D415 RGB properties
     Assumptions:
+    Parent system (URDF or sdf) will start the Gazebo Sensors plugin. See notes in the camera.gazebo.xacros.
     Simulated RGB and Depth sensors are in the same location as the RGB sensor of the physical camera.
     Simulated RGB and Depth sensors and have the same FOV as the RGB physical sensor.
     Note: physical hardware publishes pointcloud in `camera_depth_optical_frame` where this sensor will use
     the referenced camera color_frame. -->
     <xacro:property name="realsense_h_fov" value="${69 * pi/180}" />
     <xacro:property name="realsense_v_fov" value="${42 * pi/180}" />
-    <xacro:property name="fx" value="${image_width * 0.5 / tan(realsense_h_fov * 0.5)}" />
-    <xacro:property name="fy" value="${image_height * 0.5 / tan(realsense_v_fov * 0.5)}" />
-    <xacro:property name="cx" value="${image_width * 0.5}" />
-    <xacro:property name="cy" value="${image_height * 0.5}" />
+    <xacro:property name="min_depth" value="0.45" />
+    <xacro:property name="max_depth" value="3.0" />
 
-    <gazebo reference="${name}_color_frame">
-        <sensor name="${name}" type="rgbd_camera">
-            <camera>
-                <horizontal_fov>${realsense_h_fov}</horizontal_fov>
-                <image>
-                    <width>${image_width}</width>
-                    <height>${image_height}</height>
-                    <format>RGB_INT8</format>
-                </image>
-                <clip>
-                    <near>0.45</near>
-                    <far>5</far>
-                </clip>
-                <distortion>
-                    <k1>0.0</k1>
-                    <k2>0.0</k2>
-                    <k3>0.0</k3>
-                    <p1>0.0</p1>
-                    <p2>0.0</p2>
-                    <center>0.5 0.5</center>
-                </distortion>
-                <lens>
-                    <intrinsics>
-                        <fx>${fx}</fx>
-                        <fy>${fy}</fy>
-                        <cx>${cx}</cx>
-                        <cy>${cy}</cy>
-                        <s>0</s>
-                    </intrinsics>
-                    <projection>
-                        <p_fx>${fx}</p_fx>
-                        <p_fy>${fy}</p_fy>
-                        <p_cx>${cx}</p_cx>
-                        <p_cy>${cy}</p_cy>
-                        <tx>0</tx>
-                        <ty>0</ty>
-                    </projection>
-                </lens>
-                <noise>
-                    <type>gaussian</type>
-                    <mean>0</mean>
-                    <stddev>0.00</stddev>
-                </noise>
-                <depth_camera>
-                    <clip>
-                        <near>0.45</near>
-                        <far>5</far>
-                    </clip>
-                </depth_camera>
-                <optical_frame_id>${name}_color_optical_frame</optical_frame_id>
-            </camera>
-            <ignition_frame_id>${name}_color_frame</ignition_frame_id>
-            <always_on>1</always_on>
-            <update_rate>${fps}</update_rate>
-            <visualize>false</visualize>
-            <topic>${gz_topic_name}</topic>
-            <enable_metrics>false</enable_metrics>
-        </sensor>
-    </gazebo>
+    <xacro:if value="${type == 'rgbd'}">
+        <xacro:gazebo_rgbd name="${name}"
+                           fps="${fps}"
+                           gz_topic_name="${gz_topic_name}"
+                           image_width="${image_width}"
+                           image_height="${image_height}"
+                           h_fov="${realsense_h_fov}"
+                           v_fov="${realsense_v_fov}"
+                           min_depth="${min_depth}"
+                           max_depth="${max_depth}"/>
+    </xacro:if>
+    <xacro:if value="${type == 'rgb'}">
+        <xacro:gazebo_rgb name="${name}"
+                        fps="${fps}"
+                        gz_topic_name="${gz_topic_name}"
+                        image_width="${image_width}"
+                        image_height="${image_height}"
+                        h_fov="${realsense_h_fov}"
+                        v_fov="${realsense_v_fov}"
+                        triggered="${triggered}"/>
+    </xacro:if>
 
 </xacro:macro>
 </robot>

--- a/urdf/_d435.gazebo.xacro
+++ b/urdf/_d435.gazebo.xacro
@@ -1,98 +1,62 @@
 <?xml version="1.0"?>
 <robot name="gazebo_d435" xmlns:xacro="http://www.ros.org/wiki/xacro" xmlns:ignition="http://gazebosim.org/schema">
 
-<!--
-Gazebo plugins can only be included once so this xacro assumes that a parent will include and configure them.
-This xacro requires Gazebo plugin:
-  - ignition::gazebo::systems::Sensors
-  to publish simulated RGBD camera data
+<xacro:include filename="$(find realsense2_gz_description)/urdf/rgb_camera.gazebo.xacro" />
+<xacro:include filename="$(find realsense2_gz_description)/urdf/rgbd_camera.gazebo.xacro" />
 
-For example:
-<gazebo>
-  <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
-    <render_engine>ogre2</render_engine>
-  </plugin>
-</gazebo>
+<!-- Xacro args
+    name: should match the name value passed to realsense2_description sensor xacro
+    type:  valid values [rgb or rgbd]. Sensor type you would like to simulate
+    fps: the target frame rate of the camera images
+    gz_topic_name: the topic name the image and camera_info are published to Gazebo topics
+    image_width: See Realsense documentation for what the physical sensor supports
+    image_height: See Realsense documentation for what the physical sensor supports
+    trigger: valid values [true, false]. Only supported with 'type=rgb' and will only publish a single image when triggered on Gazebo topic '${name}/trigger'
+             example command line trigger
+             ign topic -t "/name/trigger" -m Boolean -p "data: true" -n 1
 -->
 <xacro:macro name="gazebo_d435" params="
   name:=camera
+  type:=rgbd
   fps:=15
   gz_topic_name:=camera
   image_width:=1280
-  image_height:=720">
+  image_height:=720
+  triggered:=false">
 
     <!-- Realsense D435 RGB properties
     Assumptions:
+    Parent system (URDF or sdf) will start the Gazebo Sensors plugin. See notes in the camera.gazebo.xacros.
     Simulated RGB and Depth sensors are in the same location as the RGB sensor of the physical camera.
     Simulated RGB and Depth sensors and have the same FOV as the RGB physical sensor.
     Note: physical hardware publishes pointcloud in `camera_depth_optical_frame` where this sensor will use
     the referenced camera color_frame. -->
-    <xacro:property name="realsense_h_fov" value="${87 * pi/180}" />
-    <xacro:property name="realsense_v_fov" value="${58 * pi/180}" />
-    <xacro:property name="fx" value="${image_width * 0.5 / tan(realsense_h_fov * 0.5)}" />
-    <xacro:property name="fy" value="${image_height * 0.5 / tan(realsense_v_fov * 0.5)}" />
-    <xacro:property name="cx" value="${image_width * 0.5}" />
-    <xacro:property name="cy" value="${image_height * 0.5}" />
+    <xacro:property name="realsense_h_fov" value="${69 * pi/180}" />
+    <xacro:property name="realsense_v_fov" value="${42 * pi/180}" />
+    <xacro:property name="min_depth" value="0.28" />
+    <xacro:property name="max_depth" value="3.0" />
 
-    <gazebo reference="${name}_color_frame">
-        <sensor name="${name}" type="rgbd_camera">
-            <camera>
-                <horizontal_fov>${realsense_h_fov}</horizontal_fov>
-                <image>
-                    <width>${image_width}</width>
-                    <height>${image_height}</height>
-                    <format>RGB_INT8</format>
-                </image>
-                <clip>
-                    <near>0.28</near>
-                    <far>5</far>
-                </clip>
-                <distortion>
-                    <k1>0.0</k1>
-                    <k2>0.0</k2>
-                    <k3>0.0</k3>
-                    <p1>0.0</p1>
-                    <p2>0.0</p2>
-                    <center>0.5 0.5</center>
-                </distortion>
-                <lens>
-                    <intrinsics>
-                        <fx>${fx}</fx>
-                        <fy>${fy}</fy>
-                        <cx>${cx}</cx>
-                        <cy>${cy}</cy>
-                        <s>0</s>
-                    </intrinsics>
-                    <projection>
-                        <p_fx>${fx}</p_fx>
-                        <p_fy>${fy}</p_fy>
-                        <p_cx>${cx}</p_cx>
-                        <p_cy>${cy}</p_cy>
-                        <tx>0</tx>
-                        <ty>0</ty>
-                    </projection>
-                </lens>
-                <noise>
-                    <type>gaussian</type>
-                    <mean>0</mean>
-                    <stddev>0.00</stddev>
-                </noise>
-                <depth_camera>
-                    <clip>
-                        <near>0.28</near>
-                        <far>5</far>
-                    </clip>
-                </depth_camera>
-                <optical_frame_id>${name}_color_optical_frame</optical_frame_id>
-            </camera>
-            <ignition_frame_id>${name}_color_frame</ignition_frame_id>
-            <always_on>1</always_on>
-            <update_rate>${fps}</update_rate>
-            <visualize>false</visualize>
-            <topic>${gz_topic_name}</topic>
-            <enable_metrics>false</enable_metrics>
-        </sensor>
-    </gazebo>
+    <xacro:if value="${type == 'rgbd'}">
+        <xacro:gazebo_rgbd name="${name}"
+                           fps="${fps}"
+                           gz_topic_name="${gz_topic_name}"
+                           image_width="${image_width}"
+                           image_height="${image_height}"
+                           h_fov="${realsense_h_fov}"
+                           v_fov="${realsense_v_fov}"
+                           min_depth="${min_depth}"
+                           max_depth="${max_depth}"/>
+    </xacro:if>
+    <xacro:if value="${type == 'rgb'}">
+        <xacro:gazebo_rgb name="${name}"
+                        fps="${fps}"
+                        gz_topic_name="${gz_topic_name}"
+                        image_width="${image_width}"
+                        image_height="${image_height}"
+                        h_fov="${realsense_h_fov}"
+                        v_fov="${realsense_v_fov}"
+                        triggered="${triggered}"/>
+    </xacro:if>
 
 </xacro:macro>
 </robot>

--- a/urdf/_d455.gazebo.xacro
+++ b/urdf/_d455.gazebo.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot name="gazebo_d405" xmlns:xacro="http://www.ros.org/wiki/xacro" xmlns:ignition="http://gazebosim.org/schema">
+<robot name="gazebo_d455" xmlns:xacro="http://www.ros.org/wiki/xacro" xmlns:ignition="http://gazebosim.org/schema">
 
 <xacro:include filename="$(find realsense2_gz_description)/urdf/rgb_camera.gazebo.xacro" />
 <xacro:include filename="$(find realsense2_gz_description)/urdf/rgbd_camera.gazebo.xacro" />
@@ -15,7 +15,7 @@
              example command line trigger
              ign topic -t "/name/trigger" -m Boolean -p "data: true" -n 1
 -->
-<xacro:macro name="gazebo_d405" params="
+<xacro:macro name="gazebo_d455" params="
   name:=camera
   type:=rgbd
   fps:=15
@@ -24,17 +24,17 @@
   image_height:=720
   triggered:=false">
 
-    <!-- Realsense D405 RGB properties
+    <!-- Realsense D455 RGB properties
     Assumptions:
     Parent system (URDF or sdf) will start the Gazebo Sensors plugin. See notes in the camera.gazebo.xacros.
     Simulated RGB and Depth sensors are in the same location as the RGB sensor of the physical camera.
     Simulated RGB and Depth sensors and have the same FOV as the RGB physical sensor.
     Note: physical hardware publishes pointcloud in `camera_depth_optical_frame` where this sensor will use
     the referenced camera color_frame. -->
-    <xacro:property name="realsense_h_fov" value="${87 * pi/180}" />
-    <xacro:property name="realsense_v_fov" value="${58 * pi/180}" />
-    <xacro:property name="min_depth" value="0.07" />
-    <xacro:property name="max_depth" value="0.5" />
+    <xacro:property name="realsense_h_fov" value="${90 * pi/180}" />
+    <xacro:property name="realsense_v_fov" value="${65 * pi/180}" />
+    <xacro:property name="min_depth" value="0.52" />
+    <xacro:property name="max_depth" value="6.0" />
 
     <xacro:if value="${type == 'rgbd'}">
         <xacro:gazebo_rgbd name="${name}"

--- a/urdf/rgb_camera.gazebo.xacro
+++ b/urdf/rgb_camera.gazebo.xacro
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<robot name="gazebo_rgb" xmlns:xacro="http://www.ros.org/wiki/xacro" xmlns:ignition="http://gazebosim.org/schema">
+
+<!--
+Gazebo plugins can only be included once so this xacro assumes that a parent will include and configure them.
+This xacro requires Gazebo plugin:
+  - ignition::gazebo::systems::Sensors
+  to publish simulated RGB camera data
+
+For example:
+<gazebo>
+  <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
+    <render_engine>ogre2</render_engine>
+  </plugin>
+</gazebo>
+-->
+<xacro:macro name="gazebo_rgb" params="
+  name:=camera
+  fps:=15
+  triggered:=false
+  gz_topic_name:=camera
+  image_width:=1280
+  image_height:=720
+  h_fov
+  v_fov">
+
+    <!--
+    Assumptions
+    Standard Gazebo RGB sensor in the same location as the physical camera.
+    If you set the Lense parameters like we do in the RGBD camera the lighting renders incorrectly.
+    -->
+
+    <gazebo reference="${name}_color_frame">
+        <sensor name="${name}" type="camera">
+            <camera>
+                <horizontal_fov>${h_fov}</horizontal_fov>
+                <image>
+                    <width>${image_width}</width>
+                    <height>${image_height}</height>
+                    <format>RGB_INT8</format>
+                </image>
+                <clip>
+                    <near>0.01</near>
+                    <far>10</far>
+                </clip>
+                <distortion>
+                    <k1>0.0</k1>
+                    <k2>0.0</k2>
+                    <k3>0.0</k3>
+                    <p1>0.0</p1>
+                    <p2>0.0</p2>
+                    <center>0.5 0.5</center>
+                </distortion>
+                <noise>
+                    <type>gaussian</type>
+                    <mean>0</mean>
+                    <stddev>0.00</stddev>
+                </noise>
+                <optical_frame_id>${name}_color_optical_frame</optical_frame_id>
+                <triggered>${triggered}</triggered>
+                <trigger_topic>${name}/trigger</trigger_topic>
+            </camera>
+            <ignition_frame_id>${name}_color_frame</ignition_frame_id>
+            <always_on>1</always_on>
+            <update_rate>${fps}</update_rate>
+            <topic>${gz_topic_name}/image</topic>
+            <enable_metrics>true</enable_metrics>
+        </sensor>
+    </gazebo>
+
+</xacro:macro>
+</robot>

--- a/urdf/rgb_camera.gazebo.xacro
+++ b/urdf/rgb_camera.gazebo.xacro
@@ -64,7 +64,7 @@ For example:
             <always_on>1</always_on>
             <update_rate>${fps}</update_rate>
             <topic>${gz_topic_name}/image</topic>
-            <enable_metrics>true</enable_metrics>
+            <enable_metrics>false</enable_metrics>
         </sensor>
     </gazebo>
 

--- a/urdf/rgbd_camera.gazebo.xacro
+++ b/urdf/rgbd_camera.gazebo.xacro
@@ -94,7 +94,7 @@ For example:
             <update_rate>${fps}</update_rate>
             <visualize>false</visualize>
             <topic>${gz_topic_name}</topic>
-            <enable_metrics>true</enable_metrics>
+            <enable_metrics>false</enable_metrics>
         </sensor>
     </gazebo>
 

--- a/urdf/rgbd_camera.gazebo.xacro
+++ b/urdf/rgbd_camera.gazebo.xacro
@@ -1,0 +1,102 @@
+<?xml version="1.0"?>
+<robot name="gazebo_rgbd" xmlns:xacro="http://www.ros.org/wiki/xacro" xmlns:ignition="http://gazebosim.org/schema">
+
+<!--
+Gazebo plugins can only be included once so this xacro assumes that a parent will include and configure them.
+This xacro requires Gazebo plugin:
+  - ignition::gazebo::systems::Sensors
+  to publish simulated RGBD camera data
+
+For example:
+<gazebo>
+  <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
+    <render_engine>ogre2</render_engine>
+  </plugin>
+</gazebo>
+-->
+<xacro:macro name="gazebo_rgbd" params="
+  name:=camera
+  fps:=15
+  gz_topic_name:=camera
+  image_width:=1280
+  image_height:=720
+  h_fov
+  v_fov
+  min_depth
+  max_depth">
+
+    <!--
+    Assumptions:
+    Simulated RGB and Depth sensors are in the same location as the RGB sensor of the physical camera.
+    Simulated RGB and Depth sensors and have the same FOV as the RGB physical sensor.
+    Note: physical hardware publishes pointcloud in `camera_depth_optical_frame` where this sensor will use
+    the referenced camera color_frame. -->
+    <xacro:property name="fx" value="${image_width * 0.5 / tan(h_fov * 0.5)}" />
+    <xacro:property name="fy" value="${image_height * 0.5 / tan(v_fov * 0.5)}" />
+    <xacro:property name="cx" value="${image_width * 0.5}" />
+    <xacro:property name="cy" value="${image_height * 0.5}" />
+    <xacro:property name="min_depth" value="0.52" />
+    <xacro:property name="max_depth" value="6.0" />
+
+    <gazebo reference="${name}_color_frame">
+        <sensor name="${name}" type="rgbd_camera">
+            <camera>
+                <horizontal_fov>${h_fov}</horizontal_fov>
+                <image>
+                    <width>${image_width}</width>
+                    <height>${image_height}</height>
+                    <format>RGB_INT8</format>
+                </image>
+                <clip>
+                    <near>0.01</near>
+                    <far>10</far>
+                </clip>
+                <distortion>
+                    <k1>0.0</k1>
+                    <k2>0.0</k2>
+                    <k3>0.0</k3>
+                    <p1>0.0</p1>
+                    <p2>0.0</p2>
+                    <center>0.5 0.5</center>
+                </distortion>
+                <lens>
+                    <intrinsics>
+                        <fx>${fx}</fx>
+                        <fy>${fy}</fy>
+                        <cx>${cx}</cx>
+                        <cy>${cy}</cy>
+                        <s>0</s>
+                    </intrinsics>
+                    <projection>
+                        <p_fx>${fx}</p_fx>
+                        <p_fy>${fy}</p_fy>
+                        <p_cx>${cx}</p_cx>
+                        <p_cy>${cy}</p_cy>
+                        <tx>0</tx>
+                        <ty>0</ty>
+                    </projection>
+                </lens>
+                <noise>
+                    <type>gaussian</type>
+                    <mean>0</mean>
+                    <stddev>0.00</stddev>
+                </noise>
+                <depth_camera>
+                    <clip>
+                        <near>${min_depth}</near>
+                        <far>${max_depth}</far>
+                    </clip>
+                </depth_camera>
+                <optical_frame_id>${name}_color_optical_frame</optical_frame_id>
+            </camera>
+            <ignition_frame_id>${name}_color_frame</ignition_frame_id>
+            <always_on>1</always_on>
+            <update_rate>${fps}</update_rate>
+            <visualize>false</visualize>
+            <topic>${gz_topic_name}</topic>
+            <enable_metrics>true</enable_metrics>
+        </sensor>
+    </gazebo>
+
+</xacro:macro>
+</robot>


### PR DESCRIPTION
This PR makes it so that users can choose to reduce the default sensor type of RGBD to only RGB which helps reduce simulation load if that is all that is needed by your algorithm or observation. This PR also includes an option to select if the RGB camera is `triggered` via a topic (I was not able to get this working on the RGBD camera but will keep trying).