### PR TITLE
Update near clip distance

### DIFF
--- a/urdf/rgb_camera.gazebo.xacro
+++ b/urdf/rgb_camera.gazebo.xacro
@@ -40,7 +40,7 @@ For example:
                     <format>RGB_INT8</format>
                 </image>
                 <clip>
-                    <near>0.02</near>
+                    <near>0.05</near>
                     <far>10</far>
                 </clip>
                 <distortion>

--- a/urdf/rgb_camera.gazebo.xacro
+++ b/urdf/rgb_camera.gazebo.xacro
@@ -40,7 +40,7 @@ For example:
                     <format>RGB_INT8</format>
                 </image>
                 <clip>
-                    <near>0.01</near>
+                    <near>0.02</near>
                     <far>10</far>
                 </clip>
                 <distortion>

--- a/urdf/rgbd_camera.gazebo.xacro
+++ b/urdf/rgbd_camera.gazebo.xacro
@@ -48,7 +48,7 @@ For example:
                     <format>RGB_INT8</format>
                 </image>
                 <clip>
-                    <near>0.01</near>
+                    <near>0.02</near>
                     <far>10</far>
                 </clip>
                 <distortion>

--- a/urdf/rgbd_camera.gazebo.xacro
+++ b/urdf/rgbd_camera.gazebo.xacro
@@ -48,7 +48,7 @@ For example:
                     <format>RGB_INT8</format>
                 </image>
                 <clip>
-                    <near>0.02</near>
+                    <near>0.05</near>
                     <far>10</far>
                 </clip>
                 <distortion>


### PR DESCRIPTION
This PR updated the `clip/near` distance to be outside the mesh of the camera. The old value caused the cameras to return gray images because all they could see was the mesh of the camera body.

To test run
`ros2 launch realsense2_gz_description example_realsense_gazebo.launch.py`
and ensure you can see the Gazebo scene in Rviz.
![image](https://github.com/user-attachments/assets/e7dc1a2e-6996-4671-b8c9-48d7b92daae6)
